### PR TITLE
Update CODEOWNERS to use github teams

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-* @silentearth @csh519 @yuzzyuzz @meanrin
+* @Samsung/CredData_maintainers

--- a/README.md
+++ b/README.md
@@ -382,6 +382,8 @@ Name | E-Mail
 [Shinhyung Choi](https://github.com/csh519) | sh519.choi@samsung.com
 [Yujeong Lee](https://github.com/yuzzyuzz) | yujeongg.lee@samsung.com
 [Oleksandra Sokol](https://github.com/meanrin) | o.sokol@samsung.com
+[Dmytro Kuzmenko](https://github.com/Dmitriy-NK) | d.kuzmenko@samsung.com
+[Arkadiy Melkonyan](https://github.com/ARKAD97) | a.melkonyan@samsung.com
 
 ## How to Contact
 Please post questions, issues, or suggestions into Issues. This is the best way to communicate with the developer.


### PR DESCRIPTION
Modify `CODEOWNERS` to use github teams to modify code owners more easily.