### PR TITLE
Add new scanner TruffleHog

### DIFF
--- a/benchmark/__main__.py
+++ b/benchmark/__main__.py
@@ -2,7 +2,9 @@ from argparse import ArgumentParser
 
 from benchmark.app import Benchmark
 
-SCANNER_LIST = ["credsweeper", "credential_digger", "detect_secrets", "gitleaks", "shhgit", "trufflehog3", "wraith"]
+SCANNER_LIST = [
+    "credsweeper", "credential_digger", "detect_secrets", "gitleaks", "shhgit", "trufflehog", "trufflehog3", "wraith"
+]
 
 
 def get_arguments() -> ArgumentParser.parse_args:

--- a/benchmark/common/constants.py
+++ b/benchmark/common/constants.py
@@ -6,6 +6,7 @@ class ScannerType:
     CREDENTIAL_DIGGER = "credential_digger"
     WRAITH = "wraith"
     TRUFFLEHOG3 = "trufflehog3"
+    TRUFFLEHOG = "trufflehog"
 
 
 class LineStatus:
@@ -23,3 +24,4 @@ class URL:
     CREDENTIAL_DIGGER = "credential_digger"
     WRAITH = "wraith"
     TRUFFLEHOG3 = "trufflehog3"
+    TRUFFLEHOG = "trufflehog"

--- a/benchmark/scanner/__init__.py
+++ b/benchmark/scanner/__init__.py
@@ -5,5 +5,6 @@ from benchmark.scanner.credsweeper import CredSweeper
 from benchmark.scanner.detect_secrets import DetectSecrets
 from benchmark.scanner.gitleaks import Gitleaks
 from benchmark.scanner.shhgit import Shhgit
+from benchmark.scanner.trufflehog import TruffleHog
 from benchmark.scanner.trufflehog3 import TruffleHog3
 from benchmark.scanner.wraith import Wraith

--- a/benchmark/scanner/scanner_factory.py
+++ b/benchmark/scanner/scanner_factory.py
@@ -1,6 +1,6 @@
 from benchmark.common import ScannerType
-from benchmark.scanner import (CredentialDigger, CredSweeper, DetectSecrets, Gitleaks, Scanner, Shhgit, TruffleHog3,
-                               Wraith)
+from benchmark.scanner import (CredentialDigger, CredSweeper, DetectSecrets, Gitleaks, Scanner, Shhgit, TruffleHog,
+                               TruffleHog3, Wraith)
 
 
 class ScannerFactory:
@@ -20,3 +20,5 @@ class ScannerFactory:
             return Wraith(working_dir, cred_data_dir)
         elif scanner_type == ScannerType.TRUFFLEHOG3:
             return TruffleHog3(working_dir, cred_data_dir)
+        elif scanner_type == ScannerType.TRUFFLEHOG:
+            return TruffleHog(working_dir, cred_data_dir)

--- a/benchmark/scanner/trufflehog.py
+++ b/benchmark/scanner/trufflehog.py
@@ -1,0 +1,69 @@
+import base64
+import json
+import os
+import subprocess
+from typing import Tuple
+
+from benchmark.common.constants import URL, LineStatus, ScannerType
+from benchmark.scanner.scanner import Scanner
+
+
+class TruffleHog(Scanner):
+    def __init__(self, working_dir, cred_data_dir):
+        super().__init__(ScannerType.TRUFFLEHOG, URL.TRUFFLEHOG, working_dir, cred_data_dir)
+        self.output_dir: str = f"{self.scanner_dir}/output.json"
+
+    @property
+    def output_dir(self) -> str:
+        return self._output_dir
+
+    @output_dir.setter
+    def output_dir(self, output_dir: str) -> None:
+        self._output_dir = output_dir
+
+    def init_scanner(self) -> None:
+        self.trufflehog_path = f"{os.path.dirname(os.path.realpath(__file__))}/bin/trufflehog/trufflehog"
+
+    def run_scanner(self) -> None:
+        self.init_scanner()
+        with open(self.output_dir, "w") as f:
+            f.write(
+                subprocess.Popen(
+                    [self.trufflehog_path, "filesystem", f"--directory={self.cred_data_dir}/data", "--json"],
+                    cwd=self.scanner_dir,
+                    stdout=subprocess.PIPE).communicate()[0].decode("utf-8"))
+
+    def parse_result(self) -> Tuple[int, int, int, int]:
+        data = []
+        with open(self.output_dir, "r") as f:
+            lines = f.readlines()
+            for line in lines:
+                data.append(json.loads(line))
+
+        result_cnt = lost_cnt = true_cnt = false_cnt = 0
+
+        for line_data in data:
+            file_path = line_data["SourceMetadata"]["Data"]["Filesystem"]["file"]
+            if file_path.split("/")[-1] == "LICENSE":
+                continue
+            result_cnt += 1
+            line = base64.b64decode(line_data["Raw"]).decode("utf-8")
+            line_num = self._get_line_num(file_path, line)
+            check_line_result, _, _ = self.check_line_from_meta(file_path, line_num)
+            if check_line_result == LineStatus.TRUE:
+                true_cnt += 1
+            elif check_line_result == LineStatus.FALSE:
+                false_cnt += 1
+            elif check_line_result == LineStatus.NOT_IN_DB:
+                lost_cnt += 1
+            elif check_line_result == LineStatus.CHECKED:
+                result_cnt -= 1
+
+        return result_cnt, lost_cnt, true_cnt, false_cnt
+
+    def _get_line_num(self, file_path: str, match: str) -> int:
+        with open(file_path, "r") as f:
+            for line_num, line in enumerate(f.readlines()):
+                if match in line:
+                    return line_num + 1
+        return -1


### PR DESCRIPTION
[TruffleHog](https://github.com/trufflesecurity/trufflehog) recently released v3.0.0 and it has `filesystem` option, so finally  we can test it with `CredData`.

- Add [TruffleHog v3.2.3](https://github.com/trufflesecurity/trufflehog/releases/tag/v3.2.3) linux arm64 binary in `benchmark/scanner/bin/trufflehog`
- Add `TruffleHog` scanner class