### PR TITLE
fix markup for Private keys - failure during download data

### DIFF
--- a/meta/387016a6.csv
+++ b/meta/387016a6.csv
@@ -145,8 +145,8 @@ Id,FileID,Domain,RepoName,FilePath,LineStart:LineEnd,GroundTruth,WithWords,Value
 18555,00da0713,GitHub,387016a6,data/387016a6/test/du.yml,126:126,F,F,,,F,F,,,,,0,0,F,F,F,
 18556,00da0713,GitHub,387016a6,data/387016a6/test/du.yml,23:23,F,F,,,F,F,,,,,0,0,F,F,F,
 18557,00da0713,GitHub,387016a6,data/387016a6/test/du.yml,1575:1575,F,F,,,F,F,,,,,0,0,F,F,F,
-18642,2cedcd0c,GitHub,387016a6,data/387016a6/test/fx.pem,1:7,T,F,,,F,F,,,,,0,0,F,F,F,Private Key
-18644,cd2f735c,GitHub,387016a6,data/387016a6/test/dp.pem,1:7,T,F,,,F,F,,,,,0,0,F,F,F,Private Key
+18642,2cedcd0c,GitHub,387016a6,data/387016a6/test/fx.pem,1:7,T,T,,,F,F,Any,Private,,Unknown,0.00,36,F,F,F,Private Key
+18644,cd2f735c,GitHub,387016a6,data/387016a6/test/dp.pem,1:7,T,T,,,F,F,Any,Private,,Unknown,0.00,36,F,F,F,Private Key
 18680,8710d4d0,GitHub,387016a6,data/387016a6/test/ds.yml,110:110,F,F,,,F,F,,,,,0,0,F,F,F,
 18681,8710d4d0,GitHub,387016a6,data/387016a6/test/ds.yml,89:89,F,F,,,F,F,,,,,0,0,F,F,F,
 18682,00da0713,GitHub,387016a6,data/387016a6/test/du.yml,525:525,F,F,,,F,F,,,,,0,0,F,F,F,

--- a/meta/3d82970b.csv
+++ b/meta/3d82970b.csv
@@ -27,7 +27,6 @@ Id,FileID,Domain,RepoName,FilePath,LineStart:LineEnd,GroundTruth,WithWords,Value
 34073,4ea0570b,GitHub,3d82970b,data/3d82970b/test/i.js,5:5,T,F,13,97,F,F,Any,,JSON Web Token,Token,5.10,84,F,F,F,Predefined Pattern
 34074,39a14b64,GitHub,3d82970b,data/3d82970b/test/k.js,13:13,T,F,13,134,F,F,Any,,JSON Web Token,Token,5.33,121,F,F,F,Predefined Pattern
 34483,d6336c49,GitHub,3d82970b,data/3d82970b/test/j.js,224:224,T,F,13,157,F,F,Any,,JSON Web Token,Token,5.13,144,F,F,F,Predefined Pattern
-
 34484,d6336c49,GitHub,3d82970b,data/3d82970b/test/j.js,73:73,T,F,13,157,F,F,Any,,JSON Web Token,Token,5.29,144,F,F,F,Predefined Pattern
 35300,08273ac2,GitHub,3d82970b,data/3d82970b/test/h.pem,1:27,T,T,,,F,F,Any,Private,,Unknown,2.53,31,F,F,F,Private Key
 35532,4a698eba,GitHub,3d82970b,data/3d82970b/test/d.pem,9:18,F,F,,,F,F,,,,,0,0,F,F,F,

--- a/meta/3d82970b.csv
+++ b/meta/3d82970b.csv
@@ -27,6 +27,7 @@ Id,FileID,Domain,RepoName,FilePath,LineStart:LineEnd,GroundTruth,WithWords,Value
 34073,4ea0570b,GitHub,3d82970b,data/3d82970b/test/i.js,5:5,T,F,13,97,F,F,Any,,JSON Web Token,Token,5.10,84,F,F,F,Predefined Pattern
 34074,39a14b64,GitHub,3d82970b,data/3d82970b/test/k.js,13:13,T,F,13,134,F,F,Any,,JSON Web Token,Token,5.33,121,F,F,F,Predefined Pattern
 34483,d6336c49,GitHub,3d82970b,data/3d82970b/test/j.js,224:224,T,F,13,157,F,F,Any,,JSON Web Token,Token,5.13,144,F,F,F,Predefined Pattern
+
 34484,d6336c49,GitHub,3d82970b,data/3d82970b/test/j.js,73:73,T,F,13,157,F,F,Any,,JSON Web Token,Token,5.29,144,F,F,F,Predefined Pattern
 35300,08273ac2,GitHub,3d82970b,data/3d82970b/test/h.pem,1:27,T,T,,,F,F,Any,Private,,Unknown,2.53,31,F,F,F,Private Key
 35532,4a698eba,GitHub,3d82970b,data/3d82970b/test/d.pem,9:18,F,F,,,F,F,,,,,0,0,F,F,F,

--- a/meta/533c47c6.csv
+++ b/meta/533c47c6.csv
@@ -111,7 +111,7 @@ Id,FileID,Domain,RepoName,FilePath,LineStart:LineEnd,GroundTruth,WithWords,Value
 48350,6ff887a6,GitHub,533c47c6,data/533c47c6/test/bo.py,102:107,T,T,,,F,F,Any,Private,,Unknown,2.45,30,F,F,F,Private Key
 48351,6ff887a6,GitHub,533c47c6,data/533c47c6/test/bo.py,94:98,T,T,,,F,F,Any,Private,,Unknown,2.45,30,F,F,F,Private Key
 48352,53443fb2,GitHub,533c47c6,data/533c47c6/test/bp.key,1:28,T,T,,,F,F,Any,Private,,Unknown,2.45,30,F,F,F,Private Key
-48353,4314246e,GitHub,533c47c6,data/533c47c6/test/bq.key,1:27,T,,F,F,F,Private Key
+48353,4314246e,GitHub,533c47c6,data/533c47c6/test/bq.key,1:27,T,T,,,F,F,Any,Private,,Unknown,2.45,30,F,F,F,Private Key
 49152,6ff887a6,GitHub,533c47c6,data/533c47c6/test/bo.py,61:75,T,T,,,F,F,Any,Private,,Unknown,2.53,31,F,F,F,Private Key
 55171,da24b355,GitHub,533c47c6,data/533c47c6/test/bh.py,112:112,F,F,,,F,F,,,,,0,0,F,F,F,
 55172,da24b355,GitHub,533c47c6,data/533c47c6/test/bh.py,121:121,F,F,,,F,F,,,,,0,0,F,F,F,

--- a/meta/533c47c6.csv
+++ b/meta/533c47c6.csv
@@ -41,7 +41,7 @@ Id,FileID,Domain,RepoName,FilePath,LineStart:LineEnd,GroundTruth,WithWords,Value
 18475,34fc57e6,GitHub,533c47c6,data/533c47c6/test/bi.key,1:12,T,T,,,F,F,Any,Private,,Unknown,2.59,31,F,F,F,Private Key
 18478,12eb1b56,GitHub,533c47c6,data/533c47c6/test/ba.key,1:12,T,T,,,F,F,Any,Private,,Unknown,2.59,31,F,F,F,Private Key
 18643,6a87fa96,GitHub,533c47c6,data/533c47c6/test/bj.key,1:22,F,F,,,F,F,,,,,0,0,F,F,F,
-18646,915c8d6d,GitHub,533c47c6,data/533c47c6/test/bm.key,1:8,T,F,,,F,F,,,,,0,0,F,F,F,Private Key
+18646,915c8d6d,GitHub,533c47c6,data/533c47c6/test/bm.key,1:8,T,T,,,F,F,Any,Private,,Unknown,0.00,36,F,F,F,Private Key
 18647,f7ad502d,GitHub,533c47c6,data/533c47c6/test/bc.key,1:8,F,F,,,F,F,,,,,0,0,F,F,F,
 20223,53518520,GitHub,533c47c6,data/533c47c6/src/y.py,13:13,F,F,,,F,F,,,,,0,0,F,F,F,
 21302,6ac3f79f,GitHub,533c47c6,data/533c47c6/src/a.yml,53:53,F,F,,,F,F,,,,,0,0,F,F,F,
@@ -110,8 +110,8 @@ Id,FileID,Domain,RepoName,FilePath,LineStart:LineEnd,GroundTruth,WithWords,Value
 48348,6ff887a6,GitHub,533c47c6,data/533c47c6/test/bo.py,111:117,T,T,,,F,F,Any,Private,,Unknown,2.45,30,F,F,F,Private Key
 48350,6ff887a6,GitHub,533c47c6,data/533c47c6/test/bo.py,102:107,T,T,,,F,F,Any,Private,,Unknown,2.45,30,F,F,F,Private Key
 48351,6ff887a6,GitHub,533c47c6,data/533c47c6/test/bo.py,94:98,T,T,,,F,F,Any,Private,,Unknown,2.45,30,F,F,F,Private Key
-48352,53443fb2,GitHub,533c47c6,data/533c47c6/test/bp.key,1:28,T,F,,,F,F,,,,,0,0,F,F,F,Private Key
-48353,4314246e,GitHub,533c47c6,data/533c47c6/test/bq.key,1:27,T,F,,,F,F,,,,,0,0,F,F,F,Private Key
+48352,53443fb2,GitHub,533c47c6,data/533c47c6/test/bp.key,1:28,T,T,,,F,F,Any,Private,,Unknown,2.45,30,F,F,F,Private Key
+48353,4314246e,GitHub,533c47c6,data/533c47c6/test/bq.key,1:27,T,,F,F,F,Private Key
 49152,6ff887a6,GitHub,533c47c6,data/533c47c6/test/bo.py,61:75,T,T,,,F,F,Any,Private,,Unknown,2.53,31,F,F,F,Private Key
 55171,da24b355,GitHub,533c47c6,data/533c47c6/test/bh.py,112:112,F,F,,,F,F,,,,,0,0,F,F,F,
 55172,da24b355,GitHub,533c47c6,data/533c47c6/test/bh.py,121:121,F,F,,,F,F,,,,,0,0,F,F,F,

--- a/meta/69d49010.csv
+++ b/meta/69d49010.csv
@@ -39,7 +39,7 @@ Id,FileID,Domain,RepoName,FilePath,LineStart:LineEnd,GroundTruth,WithWords,Value
 16672,5aad918a,GitHub,69d49010,data/69d49010/test/ba.py,529:529,F,F,,,F,F,,,,,0,0,F,F,F,
 16673,5aad918a,GitHub,69d49010,data/69d49010/test/ba.py,614:614,F,F,,,F,F,,,,,0,0,F,F,F,
 16674,639b7716,GitHub,69d49010,data/69d49010/src/d.py,56:56,F,F,,,F,F,,,,,0,0,F,F,F,
-18645,0096a9db,GitHub,69d49010,data/69d49010/test/v,1:38,T,F,,,F,F,,,,,0,0,F,F,F,Private Key
+18645,0096a9db,GitHub,69d49010,data/69d49010/test/v,1:38,T,T,,,F,F,Any,Private,,Unknown,2.45,30,F,F,F,Private Key
 18914,d8bdaaee,GitHub,69d49010,data/69d49010/src/i.py,195:195,F,F,,,F,F,,,,,0,0,F,F,F,
 24644,e7bdc301,GitHub,69d49010,data/69d49010/test/bb.py,20:20,F,F,,,F,F,,,,,0,0,F,F,F,
 26305,d6cfb4be,GitHub,69d49010,data/69d49010/src/b.py,67:67,F,F,,,F,F,,,,,0,0,F,F,F,

--- a/meta/894e3377.csv
+++ b/meta/894e3377.csv
@@ -129,7 +129,7 @@ Id,FileID,Domain,RepoName,FilePath,LineStart:LineEnd,GroundTruth,WithWords,Value
 16410,40a8ca9e,GitHub,894e3377,data/894e3377/test/ce.php,939:939,F,F,,,F,F,,,,,0,0,F,F,F,
 16412,40a8ca9e,GitHub,894e3377,data/894e3377/test/ce.php,50:62,T,T,,,F,F,Any,Private,,Unknown,2.53,31,F,F,F,Private Key
 16413,692d9463,GitHub,894e3377,data/894e3377/test/by.php,141:149,T,T,,,F,F,Any,Private,,Unknown,2.39,27,F,F,F,Private Key
-16414,692d9463,GitHub,894e3377,data/894e3377/test/by.php,223:243,T,F,,,F,F,,,,,0,0,F,F,F,Private Key
+16414,692d9463,GitHub,894e3377,data/894e3377/test/by.php,223:243,T,T,,,F,F,Any,Private,,Unknown,2.45,30,F,F,F,Private Key
 16415,692d9463,GitHub,894e3377,data/894e3377/test/by.php,70:89,T,T,,,F,F,Any,Private,,Unknown,2.59,31,F,F,F,Private Key
 16418,bd9410d7,GitHub,894e3377,data/894e3377/src/ba.php,58:58,F,F,,,F,F,,,,,0,0,F,F,F,
 16422,8ddb3c9f,GitHub,894e3377,data/894e3377/src/m.php,60:60,F,F,,,F,F,,,,,0,0,F,F,F,
@@ -492,9 +492,9 @@ Id,FileID,Domain,RepoName,FilePath,LineStart:LineEnd,GroundTruth,WithWords,Value
 47347,4797ee46,GitHub,894e3377,data/894e3377/test/ca.php,326:326,F,F,,,F,F,,,,,0,0,F,F,F,
 47348,4797ee46,GitHub,894e3377,data/894e3377/test/ca.php,345:345,F,F,,,F,F,,,,,0,0,F,F,F,
 47349,4797ee46,GitHub,894e3377,data/894e3377/test/ca.php,444:444,F,F,,,F,F,,,,,0,0,F,F,F,
-47350,ac94d981,GitHub,894e3377,data/894e3377/test/cb.php,492:498,T,F,,,F,F,,,,,0,0,F,F,F,Private Key
+47350,ac94d981,GitHub,894e3377,data/894e3377/test/cb.php,492:498,T,T,,,F,F,Any,Private,,Unknown,2.45,30,F,F,F,Private Key
 47351,ac94d981,GitHub,894e3377,data/894e3377/test/cb.php,467:475,F,F,,,F,F,,,,,0,0,F,F,F,
-47352,40a8ca9e,GitHub,894e3377,data/894e3377/test/ce.php,1004:1041,T,F,,,F,F,,,,,0,0,F,F,F,Private Key
+47352,40a8ca9e,GitHub,894e3377,data/894e3377/test/ce.php,1004:1041,T,T,,,F,F,Any,Private,,Unknown,2.45,30,F,F,F,Private Key
 47353,40a8ca9e,GitHub,894e3377,data/894e3377/test/ce.php,411:426,T,T,,,F,F,Any,Private,,Unknown,2.39,27,F,F,F,Private Key
 47354,40a8ca9e,GitHub,894e3377,data/894e3377/test/ce.php,958:986,T,T,,,F,F,Any,Private,,Unknown,2.39,27,F,F,F,Private Key
 47355,40a8ca9e,GitHub,894e3377,data/894e3377/test/ce.php,272:299,T,T,,,F,F,Any,Private,,Unknown,2.39,27,F,F,F,Private Key

--- a/meta/fdbe07ac.csv
+++ b/meta/fdbe07ac.csv
@@ -61,7 +61,7 @@ Id,FileID,Domain,RepoName,FilePath,LineStart:LineEnd,GroundTruth,WithWords,Value
 35029,285a035f,GitHub,fdbe07ac,data/fdbe07ac/test/bh.go,27:41,T,T,,,F,F,Any,Private,,Unknown,2.53,31,F,F,F,Private Key
 35124,285a035f,GitHub,fdbe07ac,data/fdbe07ac/test/bh.go,8:19,T,T,,,F,F,Any,Private,,Unknown,2.59,31,F,F,F,Private Key
 35125,285a035f,GitHub,fdbe07ac,data/fdbe07ac/test/bh.go,21:25,T,T,,,F,F,Any,Private,,Unknown,2.45,30,F,F,F,Private Key
-35126,285a035f,GitHub,fdbe07ac,data/fdbe07ac/test/bh.go,43:49,T,F,,,F,F,,,,,0,0,F,F,F,Private Key
+35126,285a035f,GitHub,fdbe07ac,data/fdbe07ac/test/bh.go,43:49,T,T,,,F,F,Any,Private,,Unknown,2.45,30,F,F,F,Private Key
 35296,67a770f0,GitHub,fdbe07ac,data/fdbe07ac/src/s.key,1:27,T,T,,,F,F,Any,Private,,Unknown,2.53,31,F,F,F,Private Key
 35995,2b6903fb,GitHub,fdbe07ac,data/fdbe07ac/test/o.go,49:49,T,T,31,41,F,F,Any,,,Secret,2.13,10,F,F,F,Password
 35996,84760b8a,GitHub,fdbe07ac,data/fdbe07ac/test/ba.go,64:64,T,T,31,40,F,F,Any,,,Secret,2.60,9,F,F,F,Password


### PR DESCRIPTION
Cache for benchmark workflow are used In main repo , so download_data is not called. But in my fork the simirar cache has expired.
For multiline markup was appear that failure during download_data workflow:
```
Processing: 294/294 workbox
Finalizing dataset. Please wait a moment...
Traceback (most recent call last):
  File "download_data.py", line 474, in <module>
    obfuscate_creds(args.data_dir)
  File "download_data.py", line 453, in obfuscate_creds
    process_pem_keys(all_credentials)
  File "download_data.py", line 425, in process_pem_keys
    value_start = int(row["ValueStart"])
ValueError: invalid literal for int() with base 10: ''
```
Property markup fixes the issue.