### PR TITLE
Fix typization for methods and skip extra packages installation

### DIFF
--- a/benchmark/common/git_service.py
+++ b/benchmark/common/git_service.py
@@ -13,7 +13,7 @@ class GitService:
         git.Git(scanner_dir).pull()
 
     @classmethod
-    def set_scanner_up_to_date(cls, working_dir: str, scanner_url: str) -> None:
+    def set_scanner_up_to_date(cls, working_dir: str, scanner_url: str) -> str:
         scanner_dir = working_dir + "/temp/" + scanner_url.split("/")[-1].split(".")[0]
 
         if "https://" in scanner_url:

--- a/benchmark/scanner/credential_digger.py
+++ b/benchmark/scanner/credential_digger.py
@@ -56,7 +56,7 @@ class CredentialDigger(Scanner):
         self.init_scanner()
         self.client.scan_path(scan_path=f"{self.cred_data_dir}/data", models=["PathModel", "SnippetModel"], force=True)
 
-    def parse_result(self) -> Tuple[str, str, str, str]:
+    def parse_result(self) -> None:
         conn = sqlite3.connect(self.output_dir)
         cursor = conn.cursor()
         cursor.execute("SELECT id, file_name, line_number FROM discoveries WHERE state = 'new'")

--- a/benchmark/scanner/credsweeper.py
+++ b/benchmark/scanner/credsweeper.py
@@ -1,7 +1,6 @@
 import json
 import logging
 import subprocess
-from typing import Tuple
 
 from benchmark.common.constants import URL, LineStatus, ScannerType
 from benchmark.scanner.scanner import Scanner
@@ -33,7 +32,7 @@ class CredSweeper(Scanner):
         ],
                         cwd=self.scanner_dir)
 
-    def parse_result(self) -> Tuple[int, int, int, int]:
+    def parse_result(self) -> None:
         with open(self.output_dir, "r") as f:
             data = json.load(f)
 

--- a/benchmark/scanner/detect_secrets.py
+++ b/benchmark/scanner/detect_secrets.py
@@ -36,7 +36,7 @@ class DetectSecrets(Scanner):
         with open(self.output_dir, "w") as f:
             f.write(out[0].decode("utf8"))
 
-    def parse_result(self) -> Tuple[int, int, int, int]:
+    def parse_result(self) -> None:
         with open(self.output_dir, "r") as f:
             data = json.load(f)
 

--- a/benchmark/scanner/gitleaks.py
+++ b/benchmark/scanner/gitleaks.py
@@ -29,7 +29,7 @@ class Gitleaks(Scanner):
                          f"{self.cred_data_dir}/data", "-o", self.output_dir],
                         cwd=self.scanner_dir)
 
-    def parse_result(self) -> Tuple[int, int, int, int]:
+    def parse_result(self) -> None:
         with open(self.output_dir, "r") as f:
             data = json.load(f)
 

--- a/benchmark/scanner/shhgit.py
+++ b/benchmark/scanner/shhgit.py
@@ -31,7 +31,7 @@ class Shhgit(Scanner):
             [self.shhgit_path, "-silent", "--local", f"{self.cred_data_dir}/data", "--csv-path", self.output_dir],
             cwd=self.scanner_dir)
 
-    def parse_result(self) -> Tuple[int, int, int, int]:
+    def parse_result(self) -> None:
         with open(self.output_dir, "r") as f:
             reader = csv.DictReader(f)
 

--- a/benchmark/scanner/trufflehog.py
+++ b/benchmark/scanner/trufflehog.py
@@ -33,7 +33,7 @@ class TruffleHog(Scanner):
                     cwd=self.scanner_dir,
                     stdout=subprocess.PIPE).communicate()[0].decode("utf-8"))
 
-    def parse_result(self) -> Tuple[int, int, int, int]:
+    def parse_result(self) -> None:
         data = []
         with open(self.output_dir, "r") as f:
             lines = f.readlines()

--- a/benchmark/scanner/trufflehog3.py
+++ b/benchmark/scanner/trufflehog3.py
@@ -35,7 +35,7 @@ class TruffleHog3(Scanner):
         ],
                         cwd=self.scanner_dir)
 
-    def parse_result(self) -> Tuple[int, int, int, int]:
+    def parse_result(self) -> None:
         with open(self.output_dir, "r") as f:
             data_list = json.load(f)
 

--- a/benchmark/scanner/wraith.py
+++ b/benchmark/scanner/wraith.py
@@ -45,7 +45,7 @@ class Wraith(Scanner):
         with open(self.output_dir, "w") as f:
             f.write(self.output_lines)
 
-    def parse_result(self) -> Tuple[int, int, int, int]:
+    def parse_result(self) -> None:
         with open(self.output_dir, "r") as f:
             data = json.loads(''.join(f.readlines()[:-1]))
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,9 @@
-credentialdigger==4.9.5
-GitPython==3.1.31
-PyYAML==6.0
-virtualenv==20.23.0
-pybind11
+PyYAML==6.0.1
+GitPython==3.1.32
+virtualenv==20.24.2
+
+setuptools~=68.0.0
+pip~=23.1.2
+
+#credentialdigger==4.9.5
+


### PR DESCRIPTION
- fixed typization
- skip 'credentialdigger' installation due it not necessary
branch tested: https://github.com/Samsung/CredSweeper/pull/403