### PR TITLE
Tranform AKAMAI examples into fake credentials

### DIFF
--- a/.ci/benchmark.txt
+++ b/.ci/benchmark.txt
@@ -1,6 +1,6 @@
-META MD5 2757003b8dc1ce9e817498f27a089160
-DATA MD5 9ea9295b0757eff281d8c15df8805646
-DATA: 16703750 interested lines. MARKUP: 61929 items
+META MD5 5772251b5ba950b0ad8be843f95b7b70
+DATA MD5 0874bbca3b6d927910e8f907aaa33196
+DATA: 16703750 interested lines. MARKUP: 61935 items
 FileType           FileNumber    ValidLines    Positives    Negatives    Templates
 ---------------  ------------  ------------  -----------  -----------  -----------
                           676         69398          135          415           72
@@ -66,7 +66,7 @@ FileType           FileNumber    ValidLines    Positives    Negatives    Templat
 .gd                         1            37                         1
 .gml                        3          3075                        16
 .gni                        3          5017                        19
-.go                      1275        717403         1358         4118          741
+.go                      1275        717403         1366         4118          741
 .golden                     5          1168            1           13           29
 .gradle                    50          4295            7           90          100
 .graphql                    8           454            2           13
@@ -118,7 +118,7 @@ FileType           FileNumber    ValidLines    Positives    Negatives    Templat
 .markdown                  38          5862           54            4            1
 .markerb                    3            12                         3
 .marko                      1            21                         2
-.md                       760        180503          893         2307          584
+.md                       760        180503          893         2308          584
 .mdx                        3           549                         7
 .mjml                       1            18                         1
 .mjs                       22          4424          124          341
@@ -213,7 +213,7 @@ FileType           FileNumber    ValidLines    Positives    Negatives    Templat
 .tl                         2          2161                       154            2
 .tmpl                       5           336                         3            9
 .token                      1             1            3
-.toml                      86          2471           53          103          156
+.toml                      86          2471           53          104          156
 .tpl                        1            43                         1
 .travis                     1            34            2            3            1
 .ts                       609        109982          213         1772          197
@@ -232,7 +232,7 @@ FileType           FileNumber    ValidLines    Positives    Negatives    Templat
 .yml                      555         54516         1230          902          364
 .zsh                        6           872                        12
 .zsh-theme                  1            97                         1
-TOTAL:                  11478      16703750        15059        46311         4909
+TOTAL:                  11478      16703750        15067        46313         4909
 credsweeper result_cnt : 0, lost_cnt : 0, true_cnt : 0, false_cnt : 0
 Rules                             Positives    Negatives    Templates    Reported    TP    FP     TN     FN       FPR       FNR       ACC  PRC         RCL  F1
 ------------------------------  -----------  -----------  -----------  ----------  ----  ----  -----  -----  --------  --------  --------  -----  --------  ----
@@ -240,6 +240,7 @@ API                                     240         3172          187           
 AWS Client ID                           191           19            0                 0     0     19    191  0.000000  1.000000  0.090476         0.000000
 AWS Multi                                82           10            0                 0     0     10     82  0.000000  1.000000  0.108696         0.000000
 AWS S3 Bucket                            67           23            0                 0     0     23     67  0.000000  1.000000  0.255556         0.000000
+Akamai Credentials                        4            2            0                 0     0      2      4  0.000000  1.000000  0.333333         0.000000
 Atlassian Old PAT token                   5            8            0                 0     0      8      5  0.000000  1.000000  0.615385         0.000000
 Auth                                   1076         2759           81                 0     0   2840   1076  0.000000  1.000000  0.725230         0.000000
 Azure Access Token                       21            0            0                 0     0      0     21            1.000000  0.000000         0.000000
@@ -280,8 +281,8 @@ Seed                                      1            6            0           
 Slack Token                               4            1            0                 0     0      1      4  0.000000  1.000000  0.200000         0.000000
 Stripe Credentials                        2            0            0                 0     0      0      2            1.000000  0.000000         0.000000
 Tencent WeChat API App ID                 8            0            0                 0     0      0      8            1.000000  0.000000         0.000000
-Token                                   929         4174          455                 0     0   4629    929  0.000000  1.000000  0.832854         0.000000
+Token                                   933         4174          455                 0     0   4629    933  0.000000  1.000000  0.832255         0.000000
 Twilio Credentials                       30           39            0                 0     0     39     30  0.000000  1.000000  0.565217         0.000000
 URL Credentials                         225          168          197                 0     0    365    225  0.000000  1.000000  0.618644         0.000000
 UUID                                   1866          265            0                 0     0    265   1866  0.000000  1.000000  0.124355         0.000000
-                                      15059        46311         4909           0     0     0  46311  15059  0.000000  1.000000  0.754620         0.000000
+                                      15067        46313         4909           0     0     0  46313  15067  0.000000  1.000000  0.754529         0.000000

--- a/meta/28728ab4.csv
+++ b/meta/28728ab4.csv
@@ -848,3 +848,9 @@ Id,FileID,Domain,RepoName,FilePath,LineStart,LineEnd,GroundTruth,ValueStart,Valu
 1481131,fb100b4a,GitHub,28728ab4,data/28728ab4/test/fb100b4a.go,30,30,T,20,36,,,Auth
 1481132,fb100b4a,GitHub,28728ab4,data/28728ab4/test/fb100b4a.go,94,94,T,20,36,,,Auth
 1481133,fb100b4a,GitHub,28728ab4,data/28728ab4/test/fb100b4a.go,151,151,T,20,36,,,Auth
+1524699,c6e301fe,GitHub,28728ab4,data/28728ab4/test/c6e301fe.go,48,48,T,22,60,,,Akamai Credentials:Token
+1524700,c6e301fe,GitHub,28728ab4,data/28728ab4/test/c6e301fe.go,54,54,T,19,57,,,Akamai Credentials:Token
+1524701,c6e301fe,GitHub,28728ab4,data/28728ab4/test/c6e301fe.go,65,65,T,26,64,,,Akamai Credentials:Token
+1524702,c6e301fe,GitHub,28728ab4,data/28728ab4/test/c6e301fe.go,71,71,T,19,57,,,Akamai Credentials:Token
+1524703,d3e2cec1,GitHub,28728ab4,data/28728ab4/src/d3e2cec1.toml,13,13,F,12,,,,Akamai Credentials
+1524704,76a6fc48,GitHub,28728ab4,data/28728ab4/other/76a6fc48.md,27,27,F,12,,,,Akamai Credentials

--- a/obfuscate_creds.py
+++ b/obfuscate_creds.py
@@ -91,7 +91,7 @@ def get_obfuscated_value(value, meta_row: MetaRow):
                                            "ANVA", "AROA", "APKA", "ASCA", "ASIA", "AIza"]) \
             or value.startswith("xox") and 15 <= len(value) and value[3] in "aboprst" and '-' == value[4]:
         obfuscated_value = value[:4] + generate_value(value[4:])
-    elif any(value.startswith(x) for x in ["ya29.", "pass:", "salt:"]):
+    elif any(value.startswith(x) for x in ["ya29.", "pass:", "salt:", "akab-"]):
         obfuscated_value = value[:5] + generate_value(value[5:])
     elif any(value.startswith(x) for x in ["whsec_", "Basic ", "OAuth "]):
         obfuscated_value = value[:6] + generate_value(value[6:])
@@ -100,7 +100,7 @@ def get_obfuscated_value(value, meta_row: MetaRow):
     elif any(value.startswith(x) for x in
              ["hexpass:", "hexsalt:", "pk_live_", "rk_live_", "sk_live_", "pk_test_", "rk_test_", "sk_test_"]):
         obfuscated_value = value[:8] + generate_value(value[8:])
-    elif any(value.startswith(x) for x in ["SWMTKN-1-"]):
+    elif any(value.startswith(x) for x in ["SWMTKN-1-", "dckr_pat_", "dckr_oat_"]):
         obfuscated_value = value[:9] + generate_value(value[9:])
     elif any(value.startswith(x) for x in ["hexsecret:"]):
         obfuscated_value = value[:10] + generate_value(value[10:])

--- a/review_data.py
+++ b/review_data.py
@@ -186,6 +186,10 @@ def main(meta_dir: str,
                 print(f"Too long for Password TRUE markup!\n{row}", flush=True)
                 errors += 1
 
+        if row.LineStart != row.LineEnd and not any(x in row.Category for x in ["Multi", "PEM", "JWK", "Other"]):
+            print(f"Check multiline markup - may be not suitable for the category!\n{row}", flush=True)
+            errors += 1
+
         if row.FileID not in row.FilePath:
             print(f"FileID error!\n{row}", flush=True)
             errors += 1


### PR DESCRIPTION
- markup for AKAMAI creds
- avoid new prefixes obfuscation
- add check for id in data 
- add check wrong markup for rules which cannot be multiline