### PR TITLE
OTP / 2FA Secret markup

### DIFF
--- a/.ci/benchmark.txt
+++ b/.ci/benchmark.txt
@@ -1,5 +1,5 @@
-META MD5 2566e733a4aeee3528190cd5b5149e54
-DATA MD5 44864327e83cc9129c55cceb50566392
+META MD5 4b2bb7c290c4db1637f23e8852476589
+DATA MD5 48c031052cd50f92ae0e2ee87b96406c
 DATA: 16720463 interested lines. MARKUP: 61439 items
 FileType           FileNumber    ValidLines    Positives    Negatives
 ---------------  ------------  ------------  -----------  -----------
@@ -166,7 +166,7 @@ FileType           FileNumber    ValidLines    Positives    Negatives
 .pyx                        2          1094                        23
 .r                          4            62            5            2
 .rake                       2            51                         2
-.rb                       852        130684          423         2970
+.rb                       852        130684          424         2969
 .re                         1            31                         1
 .red                        1           159                         1
 .release                    1            13                         4
@@ -232,7 +232,7 @@ FileType           FileNumber    ValidLines    Positives    Negatives
 .yml                      555         54516         1871         1227
 .zsh                        6           872                        12
 .zsh-theme                  1            97                         1
-TOTAL:                  11516      16720463        16226        50387
+TOTAL:                  11516      16720463        16227        50386
 credsweeper result_cnt : 0, lost_cnt : 0, true_cnt : 0, false_cnt : 0
 Rules                             Positives    Negatives    Reported    TP    FP     TN     FN       FPR       FNR       ACC  PRC         RCL  F1
 ------------------------------  -----------  -----------  ----------  ----  ----  -----  -----  --------  --------  --------  -----  --------  ----
@@ -273,7 +273,7 @@ Jira / Confluence PAT token               0            4                 0     0
 Key                                    4210        16306                 0     0  16306   4210  0.000000  1.000000  0.794794         0.000000
 NKEY Seed                                58            0                 0     0      0     58            1.000000  0.000000         0.000000
 Nonce                                   117           49                 0     0     49    117  0.000000  1.000000  0.295181         0.000000
-OTP / 2FA Secret                         57            4                 0     0      4     57  0.000000  1.000000  0.065574         0.000000
+OTP / 2FA Secret                         58            3                 0     0      3     58  0.000000  1.000000  0.049180         0.000000
 Other                                     9         7442                 0     0   7442      9  0.000000  1.000000  0.998792         0.000000
 PEM Private Key                        1142           76                 0     0     76   1142  0.000000  1.000000  0.062397         0.000000
 Password                               2497         9982                 0     0   9982   2497  0.000000  1.000000  0.799904         0.000000
@@ -288,4 +288,4 @@ Token                                   949         4640                 0     0
 Twilio Credentials                       30           39                 0     0     39     30  0.000000  1.000000  0.565217         0.000000
 URL Credentials                         220          379                 0     0    379    220  0.000000  1.000000  0.632721         0.000000
 UUID                                   1866          265                 0     0    265   1866  0.000000  1.000000  0.124355         0.000000
-                                      16226        50387           0     0     0  50387  16226  0.000000  1.000000  0.756414         0.000000
+                                      16227        50386           0     0     0  50386  16227  0.000000  1.000000  0.756399         0.000000

--- a/.ci/benchmark.txt
+++ b/.ci/benchmark.txt
@@ -1,6 +1,6 @@
-META MD5 50ed3ef305ad91f334214db4eb3e152d
-DATA MD5 dac0c4d817dcc1dc209724af30e2053d
-DATA: 16720463 interested lines. MARKUP: 61437 items
+META MD5 2566e733a4aeee3528190cd5b5149e54
+DATA MD5 44864327e83cc9129c55cceb50566392
+DATA: 16720463 interested lines. MARKUP: 61439 items
 FileType           FileNumber    ValidLines    Positives    Negatives
 ---------------  ------------  ------------  -----------  -----------
                           677         69567          133          489
@@ -77,7 +77,7 @@ FileType           FileNumber    ValidLines    Positives    Negatives
 .haml                       9           191                        17
 .hbs                        2            54                         3
 .hs                        14          4140           30           65
-.html                      76         31895          114          133
+.html                      76         31895          114          134
 .idl                        3          1625           37            5
 .iml                        6           699                        30
 .in                         7          2242           10           50
@@ -89,8 +89,8 @@ FileType           FileNumber    ValidLines    Positives    Negatives
 .java                     672        144069          489         1499
 .jenkinsfile                1            58            2            6
 .jinja2                     1            64                         2
-.js                       655        531277          582         2702
-.json                     885      13114471         1321        10119
+.js                       655        531277          585         2702
+.json                     885      13114471         1321        10120
 .jsp                       13          3202            1           37
 .jsx                        7           857                        19
 .jwt                        1             1            2
@@ -166,7 +166,7 @@ FileType           FileNumber    ValidLines    Positives    Negatives
 .pyx                        2          1094                        23
 .r                          4            62            5            2
 .rake                       2            51                         2
-.rb                       852        130684          420         2970
+.rb                       852        130684          423         2970
 .re                         1            31                         1
 .red                        1           159                         1
 .release                    1            13                         4
@@ -216,7 +216,7 @@ FileType           FileNumber    ValidLines    Positives    Negatives
 .toml                      86          2471           65          251
 .tpl                        1            43                         1
 .travis                     1            34            2            4
-.ts                       609        109982          226         1970
+.ts                       609        109982          240         1970
 .tsx                       54          7914            1          120
 .ttar                       1           452                         1
 .txt                      322         81679         5238         4385
@@ -229,10 +229,10 @@ FileType           FileNumber    ValidLines    Positives    Negatives
 .xib                       11           503                       164
 .xsl                        1           311                         1
 .yaml                     168         24422          195          377
-.yml                      555         54516         1870         1227
+.yml                      555         54516         1871         1227
 .zsh                        6           872                        12
 .zsh-theme                  1            97                         1
-TOTAL:                  11516      16720463        16205        50385
+TOTAL:                  11516      16720463        16226        50387
 credsweeper result_cnt : 0, lost_cnt : 0, true_cnt : 0, false_cnt : 0
 Rules                             Positives    Negatives    Reported    TP    FP     TN     FN       FPR       FNR       ACC  PRC         RCL  F1
 ------------------------------  -----------  -----------  ----------  ----  ----  -----  -----  --------  --------  --------  -----  --------  ----
@@ -270,10 +270,10 @@ Grafana Provisioned API Key              22            1                 0     0
 JSON Web Token                          168           61                 0     0     61    168  0.000000  1.000000  0.266376         0.000000
 JWK                                      55            0                 0     0      0     55            1.000000  0.000000         0.000000
 Jira / Confluence PAT token               0            4                 0     0      4      0  0.000000            1.000000
-Jira 2FA                                 36            2                 0     0      2     36  0.000000  1.000000  0.052632         0.000000
 Key                                    4210        16306                 0     0  16306   4210  0.000000  1.000000  0.794794         0.000000
 NKEY Seed                                58            0                 0     0      0     58            1.000000  0.000000         0.000000
 Nonce                                   117           49                 0     0     49    117  0.000000  1.000000  0.295181         0.000000
+OTP / 2FA Secret                         57            4                 0     0      4     57  0.000000  1.000000  0.065574         0.000000
 Other                                     9         7442                 0     0   7442      9  0.000000  1.000000  0.998792         0.000000
 PEM Private Key                        1142           76                 0     0     76   1142  0.000000  1.000000  0.062397         0.000000
 Password                               2497         9982                 0     0   9982   2497  0.000000  1.000000  0.799904         0.000000
@@ -288,4 +288,4 @@ Token                                   949         4640                 0     0
 Twilio Credentials                       30           39                 0     0     39     30  0.000000  1.000000  0.565217         0.000000
 URL Credentials                         220          379                 0     0    379    220  0.000000  1.000000  0.632721         0.000000
 UUID                                   1866          265                 0     0    265   1866  0.000000  1.000000  0.124355         0.000000
-                                      16205        50385           0     0     0  50385  16205  0.000000  1.000000  0.756645         0.000000
+                                      16226        50387           0     0     0  50387  16226  0.000000  1.000000  0.756414         0.000000

--- a/benchmark/scanner/scanner.py
+++ b/benchmark/scanner/scanner.py
@@ -347,7 +347,7 @@ class Scanner(ABC):
                 if self.fix:
                     subprocess.check_call(
                         ["sed", "-i",
-                         f"s/{row.Id},\\(.*\\)/{row.Id},\\1:{rule}/",
+                         f"s|{row.Id},\\(.*\\)|{row.Id},\\1:{rule}|",
                          f"{self.cred_data_dir}/meta/{row.RepoName}.csv"])
                     self.meta[MetaKey(data_path, line_start, line_end)].append(lost_meta)
                     lost_meta = None

--- a/meta/0b0a8cd6.csv
+++ b/meta/0b0a8cd6.csv
@@ -51,3 +51,5 @@ Id,FileID,Domain,RepoName,FilePath,LineStart,LineEnd,GroundTruth,ValueStart,Valu
 1481064,cc466c05,GitHub,0b0a8cd6,data/0b0a8cd6/test/cc466c05.json,165,165,T,31,35,,,Password
 1494788,cc466c05,GitHub,0b0a8cd6,data/0b0a8cd6/test/cc466c05.json,892,892,F,84,104,,,Gitlab Feed Token
 1494789,cc466c05,GitHub,0b0a8cd6,data/0b0a8cd6/test/cc466c05.json,900,900,F,160,180,,,Gitlab Feed Token
+11503169,16995abc,GitHub,0b0a8cd6,data/0b0a8cd6/test/16995abc.html,177,177,F,636,668,,,OTP / 2FA Secret
+11503170,cc466c05,GitHub,0b0a8cd6,data/0b0a8cd6/test/cc466c05.json,967,967,F,140,172,,,OTP / 2FA Secret

--- a/meta/2e6b3af5.csv
+++ b/meta/2e6b3af5.csv
@@ -55,7 +55,7 @@ Id,FileID,Domain,RepoName,FilePath,LineStart,LineEnd,GroundTruth,ValueStart,Valu
 28072,b49ef96a,GitHub,2e6b3af5,data/2e6b3af5/test/src/example/api/b49ef96a.java,26,26,X,37,49,,,Secret
 28073,ddeadce0,GitHub,2e6b3af5,data/2e6b3af5/test/src/example/api/ddeadce0.java,26,26,X,37,52,,,Secret
 28253,20f14c80,GitHub,2e6b3af5,data/2e6b3af5/test/src/20f14c80.java,28,28,F,19,106,,,Other
-28261,3ff907db,GitHub,2e6b3af5,data/2e6b3af5/test/src/api/3ff907db.java,18,18,X,62,78,,,Jira 2FA:Key
+28261,3ff907db,GitHub,2e6b3af5,data/2e6b3af5/test/src/api/3ff907db.java,18,18,X,62,78,,,OTP / 2FA Secret:Key
 30572,d13e91d9,GitHub,2e6b3af5,data/2e6b3af5/test/src/d13e91d9.java,22,22,T,58,106,,,Token
 30573,d13e91d9,GitHub,2e6b3af5,data/2e6b3af5/test/src/d13e91d9.java,33,33,T,58,106,,,Token
 30574,d13e91d9,GitHub,2e6b3af5,data/2e6b3af5/test/src/d13e91d9.java,43,43,T,59,107,,,Token

--- a/meta/39def7b4.csv
+++ b/meta/39def7b4.csv
@@ -682,7 +682,7 @@ Id,FileID,Domain,RepoName,FilePath,LineStart,LineEnd,GroundTruth,ValueStart,Valu
 101448,2010d338,GitHub,39def7b4,data/39def7b4/lib/rest/2010d338.rb,383,383,F,,,,,Secret
 101449,27be9d47,GitHub,39def7b4,data/39def7b4/lib/rest/27be9d47.rb,384,384,F,,,,,Secret
 101450,7d9f5b9d,GitHub,39def7b4,data/39def7b4/lib/rest/7d9f5b9d.rb,390,390,F,,,,,Secret
-101451,be070dc3,GitHub,39def7b4,data/39def7b4/spec/be070dc3.rb,79,79,T,88,120,,,Secret
+101451,be070dc3,GitHub,39def7b4,data/39def7b4/spec/be070dc3.rb,79,79,T,88,120,,,Secret:OTP / 2FA Secret
 101452,b5ca0850,GitHub,39def7b4,data/39def7b4/spec/b5ca0850.rb,25,25,F,,,,,Token
 101453,b5ca0850,GitHub,39def7b4,data/39def7b4/spec/b5ca0850.rb,32,32,F,,,,,Token
 101454,0bed0bb2,GitHub,39def7b4,data/39def7b4/security/lib/0bed0bb2.rb,37,37,F,,,,,Other

--- a/meta/41659445.csv
+++ b/meta/41659445.csv
@@ -58,11 +58,11 @@ Id,FileID,Domain,RepoName,FilePath,LineStart,LineEnd,GroundTruth,ValueStart,Valu
 26664,d4a2a492,GitHub,41659445,data/41659445/src/d4a2a492.ts,39,39,F,,,,,Secret
 26665,d4a2a492,GitHub,41659445,data/41659445/src/d4a2a492.ts,29,29,F,,,,,Secret
 27411,eb85e4f0,GitHub,41659445,data/41659445/test/src/util/eb85e4f0.ts,8,8,X,13,23,,,Secret
-28187,91fd135b,GitHub,41659445,data/41659445/src/util/91fd135b.ts,169,169,T,65,81,,,Jira 2FA:Secret
+28187,91fd135b,GitHub,41659445,data/41659445/src/util/91fd135b.ts,169,169,T,65,81,,,OTP / 2FA Secret:Secret
 31476,5398b006,GitHub,41659445,data/41659445/test/src/5398b006.js,131,131,F,,,,,Token:Secret
 32427,b2f74201,GitHub,41659445,data/41659445/test/src/b2f74201.ts,16,16,T,16,32,,,Password:Secret
 32428,c7cb0c45,GitHub,41659445,data/41659445/test/c7cb0c45.js,8,8,T,20,59,,,Secret
-32441,c7cb0c45,GitHub,41659445,data/41659445/test/c7cb0c45.js,18,18,T,20,36,,,Jira 2FA:Secret
+32441,c7cb0c45,GitHub,41659445,data/41659445/test/c7cb0c45.js,18,18,T,20,36,,,OTP / 2FA Secret:Secret
 32442,b3356305,GitHub,41659445,data/41659445/_/b3356305.md,94,94,T,16,48,,,Secret
 33951,b3356305,GitHub,41659445,data/41659445/_/b3356305.md,447,447,T,21,53,,,Secret
 34868,bf2cd4b4,GitHub,41659445,data/41659445/test/sample/bf2cd4b4.ts,8,8,F,12,18,,,Token
@@ -95,34 +95,34 @@ Id,FileID,Domain,RepoName,FilePath,LineStart,LineEnd,GroundTruth,ValueStart,Valu
 34937,bf2cd4b4,GitHub,41659445,data/41659445/test/sample/bf2cd4b4.ts,20,20,F,12,18,,,Token
 34938,faf09b36,GitHub,41659445,data/41659445/test/faf09b36.ts,120,120,F,12,20,,,Token
 34942,faf09b36,GitHub,41659445,data/41659445/test/faf09b36.ts,132,132,F,12,20,,,Token
-35218,5398b006,GitHub,41659445,data/41659445/test/src/5398b006.js,201,201,T,15,47,,,Secret
+35218,5398b006,GitHub,41659445,data/41659445/test/src/5398b006.js,201,201,T,15,47,,,Secret:OTP / 2FA Secret
 35220,bf2cd4b4,GitHub,41659445,data/41659445/test/sample/bf2cd4b4.ts,27,27,T,13,29,,,Secret
 35221,bf2cd4b4,GitHub,41659445,data/41659445/test/sample/bf2cd4b4.ts,9,9,T,13,29,,,Password:Secret
-35233,5398b006,GitHub,41659445,data/41659445/test/src/5398b006.js,210,210,T,15,47,,,Secret
+35233,5398b006,GitHub,41659445,data/41659445/test/src/5398b006.js,210,210,T,15,47,,,Secret:OTP / 2FA Secret
 35249,bf2cd4b4,GitHub,41659445,data/41659445/test/sample/bf2cd4b4.ts,33,33,T,13,29,,,Secret
 35250,bf2cd4b4,GitHub,41659445,data/41659445/test/sample/bf2cd4b4.ts,21,21,T,13,29,,,Secret
-35252,074dc7a7,GitHub,41659445,data/41659445/test/sample/074dc7a7.ts,44,44,T,11,43,,,Secret
+35252,074dc7a7,GitHub,41659445,data/41659445/test/sample/074dc7a7.ts,44,44,T,11,43,,,Secret:OTP / 2FA Secret
 35334,074dc7a7,GitHub,41659445,data/41659445/test/sample/074dc7a7.ts,19,19,F,15,21,,,Token
 35335,074dc7a7,GitHub,41659445,data/41659445/test/sample/074dc7a7.ts,9,9,F,15,21,,,Token
 35336,074dc7a7,GitHub,41659445,data/41659445/test/sample/074dc7a7.ts,14,14,F,15,21,,,Token
 35337,074dc7a7,GitHub,41659445,data/41659445/test/sample/074dc7a7.ts,39,39,F,15,21,,,Token
 35338,074dc7a7,GitHub,41659445,data/41659445/test/sample/074dc7a7.ts,34,34,F,15,21,,,Token
-35339,074dc7a7,GitHub,41659445,data/41659445/test/sample/074dc7a7.ts,23,23,T,16,48,,,Secret
-35340,074dc7a7,GitHub,41659445,data/41659445/test/sample/074dc7a7.ts,33,33,T,16,48,,,Secret
+35339,074dc7a7,GitHub,41659445,data/41659445/test/sample/074dc7a7.ts,23,23,T,16,48,,,Secret:OTP / 2FA Secret
+35340,074dc7a7,GitHub,41659445,data/41659445/test/sample/074dc7a7.ts,33,33,T,16,48,,,Secret:OTP / 2FA Secret
 35341,074dc7a7,GitHub,41659445,data/41659445/test/sample/074dc7a7.ts,8,8,T,16,48,,,Secret
 35342,074dc7a7,GitHub,41659445,data/41659445/test/sample/074dc7a7.ts,13,13,T,16,48,,,Secret
-35343,074dc7a7,GitHub,41659445,data/41659445/test/sample/074dc7a7.ts,28,28,T,16,48,,,Secret
-35344,074dc7a7,GitHub,41659445,data/41659445/test/sample/074dc7a7.ts,18,18,T,16,48,,,Secret
-35345,074dc7a7,GitHub,41659445,data/41659445/test/sample/074dc7a7.ts,38,38,T,16,48,,,Secret
+35343,074dc7a7,GitHub,41659445,data/41659445/test/sample/074dc7a7.ts,28,28,T,16,48,,,Secret:OTP / 2FA Secret
+35344,074dc7a7,GitHub,41659445,data/41659445/test/sample/074dc7a7.ts,18,18,T,16,48,,,Secret:OTP / 2FA Secret
+35345,074dc7a7,GitHub,41659445,data/41659445/test/sample/074dc7a7.ts,38,38,T,16,48,,,Secret:OTP / 2FA Secret
 35349,074dc7a7,GitHub,41659445,data/41659445/test/sample/074dc7a7.ts,24,24,F,15,21,,,Token
 35350,074dc7a7,GitHub,41659445,data/41659445/test/sample/074dc7a7.ts,29,29,F,15,21,,,Token
-37409,5398b006,GitHub,41659445,data/41659445/test/src/5398b006.js,205,205,T,15,47,,,Secret
+37409,5398b006,GitHub,41659445,data/41659445/test/src/5398b006.js,205,205,T,15,47,,,Secret:OTP / 2FA Secret
 37410,bf2cd4b4,GitHub,41659445,data/41659445/test/sample/bf2cd4b4.ts,15,15,T,13,29,,,Password:Secret
 37420,074dc7a7,GitHub,41659445,data/41659445/test/sample/074dc7a7.ts,68,68,X,12,18,,,Token
 37421,074dc7a7,GitHub,41659445,data/41659445/test/sample/074dc7a7.ts,82,82,X,12,18,,,Token
-37422,074dc7a7,GitHub,41659445,data/41659445/test/sample/074dc7a7.ts,67,67,T,13,45,,,Secret
+37422,074dc7a7,GitHub,41659445,data/41659445/test/sample/074dc7a7.ts,67,67,T,13,45,,,Secret:OTP / 2FA Secret
 37423,074dc7a7,GitHub,41659445,data/41659445/test/sample/074dc7a7.ts,73,73,T,13,45,,,Secret
-37424,074dc7a7,GitHub,41659445,data/41659445/test/sample/074dc7a7.ts,80,80,T,13,45,,,Secret
+37424,074dc7a7,GitHub,41659445,data/41659445/test/sample/074dc7a7.ts,80,80,T,13,45,,,Secret:OTP / 2FA Secret
 47806,eb85e4f0,GitHub,41659445,data/41659445/test/src/util/eb85e4f0.ts,119,119,X,15,25,,,Secret
 47991,074dc7a7,GitHub,41659445,data/41659445/test/sample/074dc7a7.ts,78,78,F,,,,,Other
 47992,074dc7a7,GitHub,41659445,data/41659445/test/sample/074dc7a7.ts,64,64,F,,,,,Other

--- a/meta/873d2d8b.csv
+++ b/meta/873d2d8b.csv
@@ -14,8 +14,8 @@ Id,FileID,Domain,RepoName,FilePath,LineStart,LineEnd,GroundTruth,ValueStart,Valu
 32228,8b2f02c3,GitHub,873d2d8b,data/873d2d8b/example/8b2f02c3.js,95,95,T,18,58,,,Secret
 32370,43415c95,GitHub,873d2d8b,data/873d2d8b/src/template/43415c95.hbs,4,4,F,101,172,,,Other
 32371,43415c95,GitHub,873d2d8b,data/873d2d8b/src/template/43415c95.hbs,2,2,F,69,120,,,Other
-32389,201092fe,GitHub,873d2d8b,data/873d2d8b/example/conf/201092fe.js,8,8,T,16,32,,,Secret:Jira 2FA
-35251,fb92ea8f,GitHub,873d2d8b,data/873d2d8b/example/fb92ea8f.js,100,100,T,11,27,,,Secret:Jira 2FA
+32389,201092fe,GitHub,873d2d8b,data/873d2d8b/example/conf/201092fe.js,8,8,T,16,32,,,Secret:OTP / 2FA Secret
+35251,fb92ea8f,GitHub,873d2d8b,data/873d2d8b/example/fb92ea8f.js,100,100,T,11,27,,,Secret:OTP / 2FA Secret
 49166,b2bc4218,GitHub,873d2d8b,data/873d2d8b/docs/b2bc4218.md,315,315,F,,,,,Secret
 50066,b2bc4218,GitHub,873d2d8b,data/873d2d8b/docs/b2bc4218.md,498,498,F,,,,,Password
 100680,201092fe,GitHub,873d2d8b,data/873d2d8b/example/conf/201092fe.js,6,6,F,,,,,Other

--- a/meta/8ba59c91.csv
+++ b/meta/8ba59c91.csv
@@ -449,7 +449,7 @@ Id,FileID,Domain,RepoName,FilePath,LineStart,LineEnd,GroundTruth,ValueStart,Valu
 34348,836751a1,GitHub,8ba59c91,data/8ba59c91/_/836751a1.yml,63,63,T,13,37,,,Password
 34456,836751a1,GitHub,8ba59c91,data/8ba59c91/_/836751a1.yml,115,115,T,13,43,,,Password
 34477,836751a1,GitHub,8ba59c91,data/8ba59c91/_/836751a1.yml,140,140,T,13,43,,,Password
-34920,836751a1,GitHub,8ba59c91,data/8ba59c91/_/836751a1.yml,150,150,T,14,46,,,Secret
+34920,836751a1,GitHub,8ba59c91,data/8ba59c91/_/836751a1.yml,150,150,T,14,46,,,Secret:OTP / 2FA Secret
 35799,953c13b1,GitHub,8ba59c91,data/8ba59c91/src/app/953c13b1.ts,85,85,T,87,107,,,Password
 135337,953c13b1,GitHub,8ba59c91,data/8ba59c91/src/app/953c13b1.ts,85,85,T,127,147,,,Password
 35814,953c13b1,GitHub,8ba59c91,data/8ba59c91/src/app/953c13b1.ts,92,92,T,88,108,,,Password
@@ -1020,7 +1020,7 @@ Id,FileID,Domain,RepoName,FilePath,LineStart,LineEnd,GroundTruth,ValueStart,Valu
 1494483,0f193646,GitHub,8ba59c91,data/8ba59c91/test/api/0f193646.ts,18,18,T,17,25,,,Password
 1494484,22d7aaab,GitHub,8ba59c91,data/8ba59c91/test/api/22d7aaab.ts,19,19,T,17,25,,,Password
 1494485,30f056ed,GitHub,8ba59c91,data/8ba59c91/test/30f056ed.ts,33,33,T,98,122,,,Password
-1494486,3a5f9da2,GitHub,8ba59c91,data/8ba59c91/test/3a5f9da2.ts,122,122,T,55,87,,,Token
+1494486,3a5f9da2,GitHub,8ba59c91,data/8ba59c91/test/3a5f9da2.ts,122,122,T,55,87,,,Token:OTP / 2FA Secret
 1494487,4c53d4eb,GitHub,8ba59c91,data/8ba59c91/test/server/4c53d4eb.ts,257,257,T,50,185,,,Auth:Bearer Authorization
 1494488,4c53d4eb,GitHub,8ba59c91,data/8ba59c91/test/server/4c53d4eb.ts,269,269,T,50,170,,,Auth:Bearer Authorization
 1494489,4c53d4eb,GitHub,8ba59c91,data/8ba59c91/test/server/4c53d4eb.ts,291,291,T,52,211,,,Auth:JSON Web Token:Bearer Authorization
@@ -1038,7 +1038,7 @@ Id,FileID,Domain,RepoName,FilePath,LineStart,LineEnd,GroundTruth,ValueStart,Valu
 1494501,b53ce2b7,GitHub,8ba59c91,data/8ba59c91/test/api/b53ce2b7.ts,193,193,T,19,27,,,Password
 1494502,b53ce2b7,GitHub,8ba59c91,data/8ba59c91/test/api/b53ce2b7.ts,280,280,T,19,27,,,Password
 1494503,b53ce2b7,GitHub,8ba59c91,data/8ba59c91/test/api/b53ce2b7.ts,330,330,T,19,27,,,Password
-1494504,b7322662,GitHub,8ba59c91,data/8ba59c91/test/b7322662.ts,34,34,T,19,51,,,Secret
+1494504,b7322662,GitHub,8ba59c91,data/8ba59c91/test/b7322662.ts,34,34,T,19,51,,,Secret:OTP / 2FA Secret
 1494505,b7456c69,GitHub,8ba59c91,data/8ba59c91/test/api/b7456c69.ts,25,25,T,19,27,,,Password
 1494506,b7456c69,GitHub,8ba59c91,data/8ba59c91/test/api/b7456c69.ts,62,62,T,19,27,,,Password
 1494507,b7456c69,GitHub,8ba59c91,data/8ba59c91/test/api/b7456c69.ts,88,88,T,19,27,,,Password
@@ -1067,15 +1067,15 @@ Id,FileID,Domain,RepoName,FilePath,LineStart,LineEnd,GroundTruth,ValueStart,Valu
 1494530,f204a657,GitHub,8ba59c91,data/8ba59c91/test/api/f204a657.ts,94,94,T,19,27,,,Password
 1494531,f204a657,GitHub,8ba59c91,data/8ba59c91/test/api/f204a657.ts,119,119,T,19,27,,,Password
 1494532,f2bc43c7,GitHub,8ba59c91,data/8ba59c91/test/api/f2bc43c7.ts,20,20,T,17,25,,,Password
-1494533,f428bce4,GitHub,8ba59c91,data/8ba59c91/test/api/f428bce4.ts,100,100,T,53,85,,,Token
-1494534,f428bce4,GitHub,8ba59c91,data/8ba59c91/test/api/f428bce4.ts,145,145,T,53,85,,,Token
-1494535,f428bce4,GitHub,8ba59c91,data/8ba59c91/test/api/f428bce4.ts,163,163,T,19,51,,,Secret
+1494533,f428bce4,GitHub,8ba59c91,data/8ba59c91/test/api/f428bce4.ts,100,100,T,53,85,,,Token:OTP / 2FA Secret
+1494534,f428bce4,GitHub,8ba59c91,data/8ba59c91/test/api/f428bce4.ts,145,145,T,53,85,,,Token:OTP / 2FA Secret
+1494535,f428bce4,GitHub,8ba59c91,data/8ba59c91/test/api/f428bce4.ts,163,163,T,19,51,,,Secret:OTP / 2FA Secret
 1494536,f428bce4,GitHub,8ba59c91,data/8ba59c91/test/api/f428bce4.ts,187,187,T,17,47,,,Password
 1494537,f428bce4,GitHub,8ba59c91,data/8ba59c91/test/api/f428bce4.ts,223,223,T,20,40,,,Secret
 1494538,f428bce4,GitHub,8ba59c91,data/8ba59c91/test/api/f428bce4.ts,267,267,T,20,40,,,Secret
 1494539,f428bce4,GitHub,8ba59c91,data/8ba59c91/test/api/f428bce4.ts,295,295,T,20,40,,,Secret
 1494540,f428bce4,GitHub,8ba59c91,data/8ba59c91/test/api/f428bce4.ts,323,323,T,20,40,,,Secret
-1494541,f428bce4,GitHub,8ba59c91,data/8ba59c91/test/api/f428bce4.ts,350,350,T,24,56,,,Secret
+1494541,f428bce4,GitHub,8ba59c91,data/8ba59c91/test/api/f428bce4.ts,350,350,T,24,56,,,Secret:OTP / 2FA Secret
 1494542,f428bce4,GitHub,8ba59c91,data/8ba59c91/test/api/f428bce4.ts,378,378,T,24,44,,,Secret
 1494543,f428bce4,GitHub,8ba59c91,data/8ba59c91/test/api/f428bce4.ts,412,412,T,24,44,,,Secret
 1494892,c475a8a8,GitHub,8ba59c91,data/8ba59c91/test/server/c475a8a8.ts,31,31,T,60,423,,,JSON Web Token

--- a/meta/8bc560cd.csv
+++ b/meta/8bc560cd.csv
@@ -25,7 +25,7 @@ Id,FileID,Domain,RepoName,FilePath,LineStart,LineEnd,GroundTruth,ValueStart,Valu
 107272,451af7c5,GitHub,8bc560cd,data/8bc560cd/lib/spec/451af7c5.rb,85,85,T,84,100,,,OTP / 2FA Secret:Secret
 1338572,451af7c5,GitHub,8bc560cd,data/8bc560cd/lib/spec/451af7c5.rb,67,67,F,35,112,,,Auth
 1481010,451af7c5,GitHub,8bc560cd,data/8bc560cd/lib/spec/451af7c5.rb,5,5,T,26,42,,,OTP / 2FA Secret
-1481011,451af7c5,GitHub,8bc560cd,data/8bc560cd/lib/spec/451af7c5.rb,11,11,F,26,42,,,OTP / 2FA Secret
+1481011,451af7c5,GitHub,8bc560cd,data/8bc560cd/lib/spec/451af7c5.rb,11,11,T,26,42,,,OTP / 2FA Secret
 1481012,451af7c5,GitHub,8bc560cd,data/8bc560cd/lib/spec/451af7c5.rb,17,17,T,26,42,,,OTP / 2FA Secret
 1481013,451af7c5,GitHub,8bc560cd,data/8bc560cd/lib/spec/451af7c5.rb,23,23,T,26,42,,,OTP / 2FA Secret
 1481014,451af7c5,GitHub,8bc560cd,data/8bc560cd/lib/spec/451af7c5.rb,29,29,T,26,42,,,OTP / 2FA Secret

--- a/meta/8bc560cd.csv
+++ b/meta/8bc560cd.csv
@@ -1,41 +1,42 @@
 Id,FileID,Domain,RepoName,FilePath,LineStart,LineEnd,GroundTruth,ValueStart,ValueEnd,CryptographyKey,PredefinedPattern,Category
 4968,9e8b926c,GitHub,8bc560cd,data/8bc560cd/lib/spec/9e8b926c.rb,4,4,F,,,,,Token
 9125,bcacb2cb,GitHub,8bc560cd,data/8bc560cd/doc/bcacb2cb.js,82,82,F,,,,,Password
-31456,451af7c5,GitHub,8bc560cd,data/8bc560cd/lib/spec/451af7c5.rb,67,67,T,80,112,,,Secret
-31464,451af7c5,GitHub,8bc560cd,data/8bc560cd/lib/spec/451af7c5.rb,43,43,T,69,85,,,Jira 2FA:Secret
+31456,451af7c5,GitHub,8bc560cd,data/8bc560cd/lib/spec/451af7c5.rb,67,67,T,80,112,,,Secret:OTP / 2FA Secret
+31464,451af7c5,GitHub,8bc560cd,data/8bc560cd/lib/spec/451af7c5.rb,43,43,T,69,85,,,OTP / 2FA Secret:Secret
 32356,aa120f99,GitHub,8bc560cd,data/8bc560cd/doc/aa120f99.html,77,77,T,237,253,,,Secret
 32357,9beec570,GitHub,8bc560cd,data/8bc560cd/doc/9beec570.html,77,77,T,237,253,,,Secret
-35395,9e8b926c,GitHub,8bc560cd,data/8bc560cd/lib/spec/9e8b926c.rb,226,226,T,54,70,,,Jira 2FA:Secret
-35829,451af7c5,GitHub,8bc560cd,data/8bc560cd/lib/spec/451af7c5.rb,79,79,T,75,91,,,Jira 2FA:Secret
-35830,451af7c5,GitHub,8bc560cd,data/8bc560cd/lib/spec/451af7c5.rb,91,91,T,62,78,,,Jira 2FA:Secret
-35831,451af7c5,GitHub,8bc560cd,data/8bc560cd/lib/spec/451af7c5.rb,97,97,T,76,92,,,Jira 2FA:Secret
-35832,451af7c5,GitHub,8bc560cd,data/8bc560cd/lib/spec/451af7c5.rb,49,49,T,69,85,,,Secret:Jira 2FA
-35833,451af7c5,GitHub,8bc560cd,data/8bc560cd/lib/spec/451af7c5.rb,7,7,T,69,85,,,Jira 2FA:Secret
-37493,451af7c5,GitHub,8bc560cd,data/8bc560cd/lib/spec/451af7c5.rb,31,31,T,69,85,,,Jira 2FA:Secret
-37494,451af7c5,GitHub,8bc560cd,data/8bc560cd/lib/spec/451af7c5.rb,37,37,T,69,85,,,Jira 2FA:Secret
+35395,9e8b926c,GitHub,8bc560cd,data/8bc560cd/lib/spec/9e8b926c.rb,226,226,T,54,70,,,OTP / 2FA Secret:Secret
+35829,451af7c5,GitHub,8bc560cd,data/8bc560cd/lib/spec/451af7c5.rb,79,79,T,75,91,,,OTP / 2FA Secret:Secret
+35830,451af7c5,GitHub,8bc560cd,data/8bc560cd/lib/spec/451af7c5.rb,91,91,T,62,78,,,OTP / 2FA Secret:Secret
+35831,451af7c5,GitHub,8bc560cd,data/8bc560cd/lib/spec/451af7c5.rb,97,97,T,76,92,,,OTP / 2FA Secret:Secret
+35832,451af7c5,GitHub,8bc560cd,data/8bc560cd/lib/spec/451af7c5.rb,49,49,T,69,85,,,Secret:OTP / 2FA Secret
+35833,451af7c5,GitHub,8bc560cd,data/8bc560cd/lib/spec/451af7c5.rb,7,7,T,69,85,,,OTP / 2FA Secret:Secret
+37493,451af7c5,GitHub,8bc560cd,data/8bc560cd/lib/spec/451af7c5.rb,31,31,T,69,85,,,OTP / 2FA Secret:Secret
+37494,451af7c5,GitHub,8bc560cd,data/8bc560cd/lib/spec/451af7c5.rb,37,37,T,69,85,,,OTP / 2FA Secret:Secret
 42061,9e8b926c,GitHub,8bc560cd,data/8bc560cd/lib/spec/9e8b926c.rb,134,134,F,,,,,Token
 42062,9e8b926c,GitHub,8bc560cd,data/8bc560cd/lib/spec/9e8b926c.rb,155,155,F,,,,,Token
 107265,c2214302,GitHub,8bc560cd,data/8bc560cd/lib/c2214302.rb,57,57,F,,,,,Other
 107266,c2214302,GitHub,8bc560cd,data/8bc560cd/lib/c2214302.rb,59,59,F,,,,,Other
-107267,451af7c5,GitHub,8bc560cd,data/8bc560cd/lib/spec/451af7c5.rb,13,13,T,77,93,,,Jira 2FA:Secret
-107268,451af7c5,GitHub,8bc560cd,data/8bc560cd/lib/spec/451af7c5.rb,19,19,T,74,90,,,Jira 2FA:Secret
-107269,451af7c5,GitHub,8bc560cd,data/8bc560cd/lib/spec/451af7c5.rb,25,25,T,89,105,,,Jira 2FA:Secret
-107270,451af7c5,GitHub,8bc560cd,data/8bc560cd/lib/spec/451af7c5.rb,55,55,T,69,85,,,Jira 2FA:Secret
-107271,451af7c5,GitHub,8bc560cd,data/8bc560cd/lib/spec/451af7c5.rb,73,73,T,89,105,,,Jira 2FA:Secret
-107272,451af7c5,GitHub,8bc560cd,data/8bc560cd/lib/spec/451af7c5.rb,85,85,T,84,100,,,Jira 2FA:Secret
+107267,451af7c5,GitHub,8bc560cd,data/8bc560cd/lib/spec/451af7c5.rb,13,13,T,77,93,,,OTP / 2FA Secret:Secret
+107268,451af7c5,GitHub,8bc560cd,data/8bc560cd/lib/spec/451af7c5.rb,19,19,T,74,90,,,OTP / 2FA Secret:Secret
+107269,451af7c5,GitHub,8bc560cd,data/8bc560cd/lib/spec/451af7c5.rb,25,25,T,89,105,,,OTP / 2FA Secret:Secret
+107270,451af7c5,GitHub,8bc560cd,data/8bc560cd/lib/spec/451af7c5.rb,55,55,T,69,85,,,OTP / 2FA Secret:Secret
+107271,451af7c5,GitHub,8bc560cd,data/8bc560cd/lib/spec/451af7c5.rb,73,73,T,89,105,,,OTP / 2FA Secret:Secret
+107272,451af7c5,GitHub,8bc560cd,data/8bc560cd/lib/spec/451af7c5.rb,85,85,T,84,100,,,OTP / 2FA Secret:Secret
 1338572,451af7c5,GitHub,8bc560cd,data/8bc560cd/lib/spec/451af7c5.rb,67,67,F,35,112,,,Auth
-1481010,451af7c5,GitHub,8bc560cd,data/8bc560cd/lib/spec/451af7c5.rb,5,5,T,26,42,,,Jira 2FA
-1481011,451af7c5,GitHub,8bc560cd,data/8bc560cd/lib/spec/451af7c5.rb,11,11,F,26,42,,,Jira 2FA
-1481012,451af7c5,GitHub,8bc560cd,data/8bc560cd/lib/spec/451af7c5.rb,17,17,T,26,42,,,Jira 2FA
-1481013,451af7c5,GitHub,8bc560cd,data/8bc560cd/lib/spec/451af7c5.rb,23,23,T,26,42,,,Jira 2FA
-1481014,451af7c5,GitHub,8bc560cd,data/8bc560cd/lib/spec/451af7c5.rb,29,29,T,26,42,,,Jira 2FA
-1481015,451af7c5,GitHub,8bc560cd,data/8bc560cd/lib/spec/451af7c5.rb,35,35,T,26,42,,,Jira 2FA
-1481016,451af7c5,GitHub,8bc560cd,data/8bc560cd/lib/spec/451af7c5.rb,41,41,T,26,42,,,Jira 2FA
-1481017,451af7c5,GitHub,8bc560cd,data/8bc560cd/lib/spec/451af7c5.rb,47,47,T,26,42,,,Jira 2FA
-1481018,451af7c5,GitHub,8bc560cd,data/8bc560cd/lib/spec/451af7c5.rb,53,53,T,26,42,,,Jira 2FA
-1481019,451af7c5,GitHub,8bc560cd,data/8bc560cd/lib/spec/451af7c5.rb,71,71,T,26,42,,,Jira 2FA
-1481020,451af7c5,GitHub,8bc560cd,data/8bc560cd/lib/spec/451af7c5.rb,77,77,T,26,42,,,Jira 2FA
-1481021,451af7c5,GitHub,8bc560cd,data/8bc560cd/lib/spec/451af7c5.rb,83,83,T,26,42,,,Jira 2FA
-1481022,451af7c5,GitHub,8bc560cd,data/8bc560cd/lib/spec/451af7c5.rb,89,89,T,26,42,,,Jira 2FA
-1481023,451af7c5,GitHub,8bc560cd,data/8bc560cd/lib/spec/451af7c5.rb,95,95,T,26,42,,,Jira 2FA
-1481024,9e8b926c,GitHub,8bc560cd,data/8bc560cd/lib/spec/9e8b926c.rb,9,9,T,32,48,,,Jira 2FA
+1481010,451af7c5,GitHub,8bc560cd,data/8bc560cd/lib/spec/451af7c5.rb,5,5,T,26,42,,,OTP / 2FA Secret
+1481011,451af7c5,GitHub,8bc560cd,data/8bc560cd/lib/spec/451af7c5.rb,11,11,F,26,42,,,OTP / 2FA Secret
+1481012,451af7c5,GitHub,8bc560cd,data/8bc560cd/lib/spec/451af7c5.rb,17,17,T,26,42,,,OTP / 2FA Secret
+1481013,451af7c5,GitHub,8bc560cd,data/8bc560cd/lib/spec/451af7c5.rb,23,23,T,26,42,,,OTP / 2FA Secret
+1481014,451af7c5,GitHub,8bc560cd,data/8bc560cd/lib/spec/451af7c5.rb,29,29,T,26,42,,,OTP / 2FA Secret
+1481015,451af7c5,GitHub,8bc560cd,data/8bc560cd/lib/spec/451af7c5.rb,35,35,T,26,42,,,OTP / 2FA Secret
+1481016,451af7c5,GitHub,8bc560cd,data/8bc560cd/lib/spec/451af7c5.rb,41,41,T,26,42,,,OTP / 2FA Secret
+1481017,451af7c5,GitHub,8bc560cd,data/8bc560cd/lib/spec/451af7c5.rb,47,47,T,26,42,,,OTP / 2FA Secret
+1481018,451af7c5,GitHub,8bc560cd,data/8bc560cd/lib/spec/451af7c5.rb,53,53,T,26,42,,,OTP / 2FA Secret
+1481019,451af7c5,GitHub,8bc560cd,data/8bc560cd/lib/spec/451af7c5.rb,71,71,T,26,42,,,OTP / 2FA Secret
+1481020,451af7c5,GitHub,8bc560cd,data/8bc560cd/lib/spec/451af7c5.rb,77,77,T,26,42,,,OTP / 2FA Secret
+1481021,451af7c5,GitHub,8bc560cd,data/8bc560cd/lib/spec/451af7c5.rb,83,83,T,26,42,,,OTP / 2FA Secret
+1481022,451af7c5,GitHub,8bc560cd,data/8bc560cd/lib/spec/451af7c5.rb,89,89,T,26,42,,,OTP / 2FA Secret
+1481023,451af7c5,GitHub,8bc560cd,data/8bc560cd/lib/spec/451af7c5.rb,95,95,T,26,42,,,OTP / 2FA Secret
+1481024,9e8b926c,GitHub,8bc560cd,data/8bc560cd/lib/spec/9e8b926c.rb,9,9,T,32,48,,,OTP / 2FA Secret
+11503171,451af7c5,GitHub,8bc560cd,data/8bc560cd/lib/spec/451af7c5.rb,60,60,T,7,39,,,OTP / 2FA Secret

--- a/meta/e3377359.csv
+++ b/meta/e3377359.csv
@@ -15,7 +15,7 @@ Id,FileID,Domain,RepoName,FilePath,LineStart,LineEnd,GroundTruth,ValueStart,Valu
 27426,719d25bb,GitHub,e3377359,data/e3377359/_/719d25bb.php,298,298,F,337,505,,,Google Multi
 137372,719d25bb,GitHub,e3377359,data/e3377359/_/719d25bb.php,298,298,T,367,505,,,Google Multi
 137367,719d25bb,GitHub,e3377359,data/e3377359/_/719d25bb.php,298,298,F,481,505,,,Atlassian Old PAT token
-137226,87fccb9b,GitHub,e3377359,data/e3377359/_/87fccb9b.php,355,355,T,169,185,,,Jira 2FA:Password
+137226,87fccb9b,GitHub,e3377359,data/e3377359/_/87fccb9b.php,355,355,T,169,185,,,OTP / 2FA Secret:Password
 27633,9bb2e93a,GitHub,e3377359,data/e3377359/_/9bb2e93a.php,22,22,F,23,75,,,Other
 137227,bc555d60,GitHub,e3377359,data/e3377359/_/bc555d60.php,52,52,T,382,520,,,Google Multi
 27639,934f079f,GitHub,e3377359,data/e3377359/test/lib/934f079f.log,21,21,T,249,265,,,Nonce
@@ -101,8 +101,8 @@ Id,FileID,Domain,RepoName,FilePath,LineStart,LineEnd,GroundTruth,ValueStart,Valu
 130299,34a6ce8d,GitHub,e3377359,data/e3377359/modul/app/34a6ce8d.php,51,51,F,,,,,Password
 130300,1fd373f0,GitHub,e3377359,data/e3377359/_/1fd373f0.php,420,420,F,,,,,Password
 130301,1fd373f0,GitHub,e3377359,data/e3377359/_/1fd373f0.php,408,408,F,,,,,Password
-131702,6e017f34,GitHub,e3377359,data/e3377359/conf/6e017f34.php,38,38,T,35,51,,,Password:Jira 2FA
-131703,6e017f34,GitHub,e3377359,data/e3377359/conf/6e017f34.php,74,74,T,35,51,,,Password:Jira 2FA
+131702,6e017f34,GitHub,e3377359,data/e3377359/conf/6e017f34.php,38,38,T,35,51,,,Password:OTP / 2FA Secret
+131703,6e017f34,GitHub,e3377359,data/e3377359/conf/6e017f34.php,74,74,T,35,51,,,Password:OTP / 2FA Secret
 133000,047b4d21,GitHub,e3377359,data/e3377359/server/modul/app/047b4d21.php,36,36,F,,,,,Password
 133001,047b4d21,GitHub,e3377359,data/e3377359/server/modul/app/047b4d21.php,105,105,F,,,,,Password
 133002,047b4d21,GitHub,e3377359,data/e3377359/server/modul/app/047b4d21.php,154,154,F,,,,,Password


### PR DESCRIPTION
Renamed Jira 2FA rule (16 symbols) and add markups for 32 symbols